### PR TITLE
Always checkout configuration from git

### DIFF
--- a/tasks/git-checkout.yml
+++ b/tasks/git-checkout.yml
@@ -1,9 +1,13 @@
 ---
+- name: "Get configuration directory's .git stats"
+  stat: path={{nginx_drupal_config_path}}/.git
+  register: nginx_drupal_config_path_dot_git
 - name: "Remove existing configurarion directory"
   file: path={{nginx_drupal_config_path}} state=absent
+  when: nginx_drupal_config_path_dot_git.stat.exists == false
 - name: "Checkout configuration directory"
   git: dest={{nginx_drupal_config_path}} repo={{nginx_drupal_git.repo}} version={{nginx_drupal_git.version}}
   notify:
    - reload nginx
-- name: "Remove example.com configurarion file"
+- name: "Remove example.com configuration file"
   file: path={{nginx_drupal_config_path}}/sites-available/example.com.conf state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
 # tasks file for nginx-drupal
-- name: "Get configuration directory's .git stats"
-  stat: path={{nginx_drupal_config_path}}/.git
-  register: nginx_drupal_config_path_dot_git
 - include: git-checkout.yml
-  when: nginx_drupal_config_path_dot_git.stat.exists == false
 - name: "Create microcache directory"
   file: path=/var/cache/nginx/microcache state=directory
   when: nginx_drupal_microcache


### PR DESCRIPTION
This allows configuration updates by pushing a new version to the configuration repo and then running Ansible.