### PR TITLE
Fix drupal-site.j2 whitespace control

### DIFF
--- a/templates/sites-available/drupal-site.j2
+++ b/templates/sites-available/drupal-site.j2
@@ -60,14 +60,13 @@ server {
     proxy_http_version 1.1; # keep alive to the Apache upstream
     {% endif %}
 
-
-    {%- if not nginx_drupal_use_boost %}
-    {%- if not nginx_drupal_escape_uri %}
+    {% if not nginx_drupal_use_boost -%}
+    {% if not nginx_drupal_escape_uri -%}
     ################################################################
     ### Generic configuration: for most Drupal 7 sites.
     ################################################################
     include apps/drupal/drupal.conf;
-    {%- else %}
+    {% else %}
     ################################################################
     ### Configuration for Drupal 7 sites to serve URIs that need
     ### to be **escaped**
@@ -105,24 +104,24 @@ server {
     ### line below and comment out after installation. Note that
     ### there's a basic auth in front as secondary ligne of defense.
     ################################################################
-    {%- if nginx_drupal_allow_install %}
+    {% if nginx_drupal_allow_install -%}
     include apps/drupal/drupal_install.conf;
-    {%- else %}
+    {% else -%}
     #include apps/drupal/drupal_install.conf;
-    {%- endif -%}
+    {%- endif %}
 
-    {%- if nginx_drupal_upload_progress %}
+    {% if nginx_drupal_upload_progress -%}
     #################################################################
     ### Support for upload progress bar. Configurations differ for
     ### Drupal 6 and Drupal 7.
     #################################################################
     include apps/drupal/drupal_upload_progress.conf;
-    {%- endif -%}
+    {%- endif %}
 
     {%- if nginx_drupal_php_handling == 'proxy' %}
     ## Including the php-fpm status and ping pages config.
     include php_fpm_status_vhost.conf;
-    {%- endif -%}
+    {%- endif %}
 
     ## Including the Nginx stub status page for having stats about
     ## Nginx activity: http://wiki.nginx.org/HttpStubStatusModule.
@@ -231,8 +230,8 @@ server {
         return 405;
     }
 
-    {% if not nginx_drupal_use_boost %}
-    {% if not nginx_drupal_escape_uri %}
+    {% if not nginx_drupal_use_boost -%}
+    {% if not nginx_drupal_escape_uri -%}
     ################################################################
     ### Generic configuration: for most Drupal 7 sites.
     ################################################################
@@ -243,30 +242,30 @@ server {
     ### to be **escaped**
     ################################################################
     include apps/drupal/drupal_escaped.conf;
-    {% endif %}
-    {% else %}
-    {% if not nginx_drupal_escape_uri %}
+    {%- endif -%}
+    {%- else %}
+    {%- if not nginx_drupal_escape_uri %}
     #################################################################
     ### Configuration for Drupal 7 sites that use boost.
     #################################################################
     include apps/drupal/drupal_boost.conf;
-    {% else %}
+    {%- else %}
     #################################################################
     ### Configuration for Drupal 7 sites that use boost if having
     ### to serve URIs that need to be **escaped**
     #################################################################
     include apps/drupal/drupal_boost_escaped.conf;
-    {% endif %}
-    {% endif %}
+    {%- endif -%}
+    {%- endif -%}
 
-    {% if not nginx_drupal_use_drush %}
+    {%- if not nginx_drupal_use_drush %}
     #################################################################
     ### Configuration for updating the site via update.php and running
     ### cron externally. If you don't use drush for running cron use
     ### the configuration below.
     #################################################################
     include apps/drupal/drupal_cron_update.conf;
-    {% endif %}
+    {%- endif -%}
 
     ################################################################
     ### Installation handling. This should be commented out after
@@ -275,24 +274,24 @@ server {
     ### line below and comment out after installation. Note that
     ### there's a basic auth in front as secondary ligne of defense.
     ################################################################
-    {% if nginx_drupal_allow_install %}
+    {% if nginx_drupal_allow_install -%}
     include apps/drupal/drupal_install.conf;
-    {% else %}
+    {% else -%}
     #include apps/drupal/drupal_install.conf;
-    {% endif %}
+    {%- endif %}
 
-    {%- if nginx_drupal_upload_progress %}
+    {% if nginx_drupal_upload_progress -%}
     #################################################################
     ### Support for upload progress bar. Configurations differ for
     ### Drupal 6 and Drupal 7.
     #################################################################
     include apps/drupal/drupal_upload_progress.conf;
-    {%- endif -%}
+    {%- endif %}
 
-    {% if nginx_drupal_php_handling == 'proxy' %}
+    {%- if nginx_drupal_php_handling == 'proxy' %}
     ## Including the php-fpm status and ping pages config.
     include php_fpm_status_vhost.conf;
-    {% endif %}
+    {%- endif %}
 
     ## Including the Nginx stub status page for having stats about
     ## Nginx activity: http://wiki.nginx.org/HttpStubStatusModule.


### PR DESCRIPTION
The `nginx_drupal_allow_install` option was broken because its include line was put on the comments line before it. This PR fixes that and several more whitespace issues (some purely cosmetic).
