### PR TITLE
if not using drush, needs access for cron.php file

### DIFF
--- a/templates/nginx.j2
+++ b/templates/nginx.j2
@@ -211,10 +211,12 @@ http {
     ## Include the Nginx stub status allowed hosts configuration block.
     include nginx_status_allowed_hosts.conf;
 
+    {%- if not nginx_drupal_use_drush %}
     ## If you want to run cron using Drupal cron.php. i.e., you're not
     ## using drush then uncomment the line below. Specify in
     ## cron_allowed_hosts.conf which hosts can invole cron.
-    # include apps/drupal/cron_allowed_hosts.conf;
+    include apps/drupal/cron_allowed_hosts.conf;
+    {%- endif -%}
 
     ## Include blacklist for bad bot and referer blocking.
     include blacklist.conf;


### PR DESCRIPTION
When the option nginx_drupal_use_drush it's set to false need to include the cron_allowed_hosts.conf file to avoid problems of missing variables
