### PR TITLE
configurable nginx user

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following variables are available to configure the role:
   (cf. http://wiki.nginx.org/HttpFlvStreamModule), defaults to false.
 - **nginx_drupal_mp4_streaming**: Whether or not to use MP4 streaming, (cf.
   http://nginx.org/en/docs/http/ngx_http_mp4_module.html) defaults to false.
+- **nginx_drupal_user**: User running Nginx, defaults to 'www-data'
 - **nginx_drupal_http_pre_includes**: A list of file to include in the
   ```http```  context (in ```nginx.conf```), before any other directives.
 - **nginx_drupal_http_post_includes**: A list of file to include in the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ nginx_drupal_upload_progress: true
 nginx_drupal_aio: true
 nginx_drupal_flv_streaming: false
 nginx_drupal_mp4_streaming: false
+nginx_drupal_user: "www-data"
 nginx_drupal_http_core:
   client_max_body_size: "10m"
   ssl_session_cache: true

--- a/templates/nginx.j2
+++ b/templates/nginx.j2
@@ -1,7 +1,8 @@
 # -*- mode: nginx; mode: flyspell-prog;  ispell-local-dictionary: "american" -*-
 ## {{ ansible_managed }}
 ## Git ref: 81aa86d03f80e8f97d433cb541f63ee292531658
-user www-data;
+user {{nginx_drupal_user}};
+
 
 ## If you're using an Nginx version below 1.3.8 or 1.2. then uncomment
 ## the line below and set it to the number of cores of the


### PR DESCRIPTION
A new **nginx_drupal_user** variable has been added to configure the user directive in nginx.conf. Default value is www-data.