### PR TITLE
add configurable ssl ciphers, curve, protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The following variables are available to configure the role:
   (cf. http://wiki.nginx.org/HttpFlvStreamModule), defaults to false.
 - **nginx_drupal_mp4_streaming**: Whether or not to use MP4 streaming, (cf.
   http://nginx.org/en/docs/http/ngx_http_mp4_module.html) defaults to false.
+- **nginx_drupal_ssl_protocols**: List of protocols to enable, defaults to SSLv3, TLSv1, TLSv1.1, TLSv1.2
+- **nginx_drupal_ssl_ecdh_curve**: Curve to use for ECDH, defaults to secp521r1
+- **nginx_drupal_ssl_ciphers**: Ciphers to use
+  defaults to "ECDH+aRSA+AESGCM:ECDH+aRSA+SHA384:ECDH+aRSA+SHA256:ECDH:EDH+CAMELLIA:EDH+aRSA:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 - **nginx_drupal_http_pre_includes**: A list of file to include in the
   ```http```  context (in ```nginx.conf```), before any other directives.
 - **nginx_drupal_http_post_includes**: A list of file to include in the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,9 @@ nginx_drupal_mp4_streaming: false
 nginx_drupal_http_core:
   client_max_body_size: "10m"
   ssl_session_cache: true
+nginx_drupal_ssl_protocols: [ "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2" ]
+nginx_drupal_ssl_ecdh_curve: "secp521r1" 
+nginx_drupal_ssl_ciphers: "ECDH+aRSA+AESGCM:ECDH+aRSA+SHA384:ECDH+aRSA+SHA256:ECDH:EDH+CAMELLIA:EDH+aRSA:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 nginx_drupal_upstream_servers: ["unix:/var/run/php-fpm.sock", "php-fpm-zwei.sock"]
 nginx_drupal_upstream_backup_servers: ["unix:/var/run/php-fpm-bkp.sock"]
 nginx_drupal_sites: none

--- a/templates/nginx.j2
+++ b/templates/nginx.j2
@@ -118,16 +118,16 @@ http {
 
     ## Use only Perfect Forward Secrecy Ciphers. Fallback on non ECDH
     ## for crufty clients.
-    ssl_ciphers ECDH+aRSA+AESGCM:ECDH+aRSA+SHA384:ECDH+aRSA+SHA256:ECDH:EDH+CAMELLIA:EDH+aRSA:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA;
+    ssl_ciphers {{nginx_drupal_ssl_ciphers}};
 
     ## No SSL2 support. Legacy support of SSLv3.
-    ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols {{nginx_drupal_ssl_protocols|join(" ")}};
 
     ## Pregenerated Diffie-Hellman parameters.
     ssl_dhparam /etc/nginx/dh_param.pem;
 
     ## Curve to use for ECDH.
-    ssl_ecdh_curve secp521r1;
+    ssl_ecdh_curve {{nginx_drupal_ssl_ecdh_curve}};
 
     ## Enable OCSP stapling. A better way to revocate server certificates.
     ssl_stapling on;


### PR DESCRIPTION
Add 3 variables to define SSL ciphers, curve, protocols.

-  **nginx_drupal_ssl_protocols** : enable specified protocols, defaults to `[ "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2" ]`

-  **nginx_drupal_ssl_ecdh_curve** : specify the ECDH curve, default value is `secp521r1`

-  **nginx_drupal_ssl_ciphers** : specify ciphers to use, default string is  `"ECDH+aRSA+AESGCM:ECDH+aRSA+SHA384:ECDH+aRSA+SHA256:ECDH:EDH+CAMELLIA:EDH+aRSA:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
`